### PR TITLE
Update the "Related Work" section

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MicroCoverage"
 uuid = "735f9d89-249f-4fc4-9125-480239e6a78f"
 authors = ["Dilum Aluthge <dilum@aluthge.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [compat]
 julia = "1.3"

--- a/README.md
+++ b/README.md
@@ -65,5 +65,3 @@ a file named `foo.jl.microcov` with the following contents:
 ## Related Work
 
 1. [https://github.com/StephenVavasis/microcoverage](https://github.com/StephenVavasis/microcoverage)
-2. [https://github.com/JuliaCI/Coverage.jl](https://github.com/JuliaCI/Coverage.jl)
-3. [https://github.com/JuliaCI/CoverageTools.jl](https://github.com/JuliaCI/CoverageTools.jl)


### PR DESCRIPTION
Technically, `Coverage.jl` and `CoverageTools.jl` don't actually _generate_ coverage information; they _process_ coverage information after it has been generated by Julia's built-in code coverage functionality.

On the other hand, this package ([`bcbi/MicroCoverage.jl`](https://github.com/bcbi/MicroCoverage.jl)) generates coverage information, and does not require the code coverage functionality built into the Julia language itself.

As far as I am aware, the only other repository that does the same thing as `MicroCoverage.jl` is [`StephenVavasis/microcoverage`](https://github.com/StephenVavasis/microcoverage).